### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Ruby_10/security/code-scanning/1](https://github.com/Brook-5686/Ruby_10/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `ApplicationController` class. The best way to do this is by calling the `protect_from_forgery` method with the `:exception` strategy, which will raise an exception if an invalid CSRF token is provided. This ensures that any state-changing requests without a valid CSRF token will be rejected, providing robust protection against CSRF attacks.

We will add the `protect_from_forgery with: :exception` line inside the `ApplicationController` class definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
